### PR TITLE
ConsolePure 256-bit color output support and some typo fixes

### DIFF
--- a/mirai-console-graphical/src/main/kotlin/net/mamoe/mirai/console/graphical/controller/MiraiGraphicalUIController.kt
+++ b/mirai-console-graphical/src/main/kotlin/net/mamoe/mirai/console/graphical/controller/MiraiGraphicalUIController.kt
@@ -13,6 +13,7 @@ import net.mamoe.mirai.console.graphical.view.VerificationCodeFragment
 import net.mamoe.mirai.console.plugins.PluginManager
 import net.mamoe.mirai.console.utils.MiraiConsoleUI
 import net.mamoe.mirai.utils.LoginSolver
+import net.mamoe.mirai.utils.SimpleLogger.LogPriority
 import tornadofx.*
 
 class MiraiGraphicalUIController : Controller(), MiraiConsoleUI {
@@ -38,6 +39,11 @@ class MiraiGraphicalUIController : Controller(), MiraiConsoleUI {
             0L -> mainLog.add(message)
             else -> cache[identity]?.logHistory?.add(message)
         }
+    }
+
+    // 修改interface之后用来暂时占位
+    override fun pushLog(priority: LogPriority, identityStr: String, identity: Long, message: String) {
+        this.pushLog(identity, message)
     }
 
     override fun prePushBot(identity: Long) = Platform.runLater {

--- a/mirai-console-terminal/src/main/kotlin/net/mamoe/mirai/console/MiraiConsoleTerminalUI.kt
+++ b/mirai-console-terminal/src/main/kotlin/net/mamoe/mirai/console/MiraiConsoleTerminalUI.kt
@@ -24,6 +24,7 @@ import net.mamoe.mirai.console.MiraiConsoleTerminalUI.LoggerDrawer.drawLog
 import net.mamoe.mirai.console.MiraiConsoleTerminalUI.LoggerDrawer.redrawLogs
 import net.mamoe.mirai.console.utils.MiraiConsoleUI
 import net.mamoe.mirai.utils.LoginSolver
+import net.mamoe.mirai.utils.SimpleLogger.LogPriority
 import java.awt.Image
 import java.awt.image.BufferedImage
 import java.io.File
@@ -82,6 +83,11 @@ object MiraiConsoleTerminalUI : MiraiConsoleUI {
         if (identity == screens[currentScreenId]) {
             drawLog(message)
         }
+    }
+
+    // 修改interface之后用来暂时占位
+    override fun pushLog(priority: LogPriority, identityStr: String, identity: Long, message: String) {
+        this.pushLog(identity, message)
     }
 
     override fun prePushBot(identity: Long) {

--- a/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/ConsoleUpdater.kt
+++ b/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/ConsoleUpdater.kt
@@ -11,24 +11,26 @@ const val CONSOLE_TERMINAL = "Terminal"
 const val CONSOLE_GRAPHICAL = "Graphical"
 
 
-object ConsoleUpdator{
+object ConsoleUpdater {
 
     @Suppress("SpellCheckingInspection")
-    private object Links:HashMap<String,Map<String,String>>() {
-       init {
-           put(CONSOLE_PURE, mapOf(
-               "version" to "/net/mamoe/mirai-console/"
-           ))
-       }
+    private object Links : HashMap<String, Map<String, String>>() {
+        init {
+            put(
+                CONSOLE_PURE, mapOf(
+                    "version" to "/net/mamoe/mirai-console/"
+                )
+            )
+        }
     }
 
 
     var consoleType = CONSOLE_PURE
 
-    fun getFile():File?{
+    fun getFile(): File? {
         contentPath.listFiles()?.forEach { file ->
             if (file != null && file.extension == "jar") {
-                if(file.name.contains("mirai-console")) {
+                if (file.name.contains("mirai-console")) {
                     when (consoleType) {
                         CONSOLE_PURE -> {
                             return file
@@ -40,7 +42,7 @@ object ConsoleUpdator{
         return null
     }
 
-    suspend fun versionCheck(type:String) {
+    suspend fun versionCheck(type: String) {
         this.consoleType = type
         println("Fetching Newest Console Version of $type")
         val newest = getNewestVersion()
@@ -55,23 +57,23 @@ object ConsoleUpdator{
     }
 
 
-    private suspend fun getNewestVersion():String{
+    private suspend fun getNewestVersion(): String {
         try {
             return """>([0-9])*\.([0-9])*\.([0-9])*/""".toRegex().findAll(
-                Http.get<String> {
-                    url {
-                        protocol = URLProtocol.HTTPS
-                        host = "jcenter.bintray.com"
-                        path(Links[consoleType]!!["version"] ?: error("Unknown Console Type"))
+                    Http.get<String> {
+                        url {
+                            protocol = URLProtocol.HTTPS
+                            host = "jcenter.bintray.com"
+                            path(Links[consoleType]!!["version"] ?: error("Unknown Console Type"))
+                        }
                     }
-                }
-            ).asSequence()
+                ).asSequence()
                 .map { it.value.drop(1).dropLast(1) }
                 .maxBy {
-                it.split('.').foldRightIndexed(0) { index: Int, s: String, acc: Int ->
-                    acc + 100.0.pow(2 - index).toInt() * (s.toIntOrNull() ?: 0)
-                }
-            }!!
+                    it.split('.').foldRightIndexed(0) { index: Int, s: String, acc: Int ->
+                        acc + 100.0.pow(2 - index).toInt() * (s.toIntOrNull() ?: 0)
+                    }
+                }!!
         } catch (e: Exception) {
             println("Failed to fetch newest Console version, please seek for help")
             e.printStackTrace()
@@ -80,9 +82,9 @@ object ConsoleUpdator{
         }
     }
 
-    fun getCurrentVersion():String{
+    fun getCurrentVersion(): String {
         val file = getFile()
-        if(file != null) {
+        if (file != null) {
             val numberVersion = """([0-9])*\.([0-9])*\.([0-9])*""".toRegex().find(file.name)?.value
             if (numberVersion != null) {
                 return numberVersion + file.name.substringAfter(numberVersion).substringBefore(".jar")
@@ -91,7 +93,7 @@ object ConsoleUpdator{
         return "0.0.0"
     }
 
-    private fun getProjectName():String{
+    private fun getProjectName(): String {
         return if (consoleType == CONSOLE_PURE) {
             "mirai-console"
         } else {
@@ -99,12 +101,12 @@ object ConsoleUpdator{
         }
     }
 
-    private suspend fun downloadConsole(version:String){
-        tryNTimesOrQuit(3,"Failed to download Console, please seek for help") {
-            Http.downloadMavenArchive("net/mamoe",getProjectName(),version)
+    private suspend fun downloadConsole(version: String) {
+        tryNTimesOrQuit(3, "Failed to download Console, please seek for help") {
+            Http.downloadMavenArchive("net/mamoe", getProjectName(), version)
                 .saveToContent("${getProjectName()}-$version.jar")
         }
         LibManager.clearLibs()
-        LibManager.addDependencyRequest("net/mamoe",getProjectName(),version)
+        LibManager.addDependencyRequest("net/mamoe", getProjectName(), version)
     }
 }

--- a/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/WrapperMain.kt
+++ b/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/WrapperMain.kt
@@ -59,19 +59,19 @@ object WrapperMain {
                 CoreUpdator.versionCheck()
             }
             launch {
-                ConsoleUpdator.versionCheck(type)
+                ConsoleUpdater.versionCheck(type)
             }
         }
         println("Version check complete, starting Mirai")
         println("Core    :" + CoreUpdator.getCore()!!)
         println("Protocol:" + CoreUpdator.getProtocolLib()!!)
-        println("Console :" + ConsoleUpdator.getFile()!! )
+        println("Console :" + ConsoleUpdater.getFile()!! )
         println("Root    :" + System.getProperty("user.dir") + "/")
 
         val loader = MiraiClassLoader(
             CoreUpdator.getCore()!!,
             CoreUpdator.getProtocolLib()!!,
-            ConsoleUpdator.getFile()!!,
+            ConsoleUpdater.getFile()!!,
             this.javaClass.classLoader
         )
         when(type) {
@@ -80,7 +80,7 @@ object WrapperMain {
                 loader.loadClass(
                     "net.mamoe.mirai.console.pure.MiraiConsolePureLoader"
                 ).getMethod("load", String::class.java,String::class.java)
-                    .invoke(null,CoreUpdator.getCurrentVersion(),ConsoleUpdator.getCurrentVersion())
+                    .invoke(null,CoreUpdator.getCurrentVersion(),ConsoleUpdater.getCurrentVersion())
             }
         }
     }

--- a/mirai-console/src/main/kotlin/net/mamoe/mirai/console/MiraiConsole.kt
+++ b/mirai-console/src/main/kotlin/net/mamoe/mirai/console/MiraiConsole.kt
@@ -19,6 +19,7 @@ import net.mamoe.mirai.console.command.ConsoleCommandSender
 import net.mamoe.mirai.console.command.DefaultCommands
 import net.mamoe.mirai.console.plugins.PluginManager
 import net.mamoe.mirai.console.utils.MiraiConsoleUI
+import net.mamoe.mirai.utils.SimpleLogger.LogPriority
 import net.mamoe.mirai.utils.cryptor.ECDH
 
 
@@ -27,7 +28,7 @@ object MiraiConsole {
      * 发布的版本名
      */
     const val build = "Pkmon"
-    lateinit var version:String
+    lateinit var version: String
 
     /**
      * 获取从Console登陆上的Bot, Bots
@@ -162,15 +163,28 @@ object MiraiConsole {
             )
         }
 
+        operator fun invoke(priority: LogPriority, identityStr: String, identity: Long, any: Any? = null) {
+            if (any != null) {
+                frontEnd.pushLog(priority, identityStr, identity, "$any")
+            }
+        }
+
+        operator fun invoke(priority: LogPriority, identityStr: String, identity: Long, e: Exception? = null) {
+            if (e != null) {
+                frontEnd.pushLog(priority, identityStr, identity, "${e.stackTrace}")
+            }
+        }
+
+        // 设置默认的pushLog输出为 INFO 类型
         operator fun invoke(identityStr: String, identity: Long, any: Any? = null) {
             if (any != null) {
-                frontEnd.pushLog(identity, "$identityStr: $any")
+                frontEnd.pushLog(LogPriority.INFO, identityStr, identity, "$any")
             }
         }
 
         operator fun invoke(identityStr: String, identity: Long, e: Exception? = null) {
             if (e != null) {
-                frontEnd.pushLog(identity, "$identityStr: ${e.stackTrace}")
+                frontEnd.pushLog(LogPriority.INFO, identityStr, identity, "${e.stackTrace}")
             }
         }
     }

--- a/mirai-console/src/main/kotlin/net/mamoe/mirai/console/command/Command.kt
+++ b/mirai-console/src/main/kotlin/net/mamoe/mirai/console/command/Command.kt
@@ -19,14 +19,17 @@ import net.mamoe.mirai.console.plugins.PluginBase
 import net.mamoe.mirai.contact.Contact
 import net.mamoe.mirai.contact.sendMessage
 import net.mamoe.mirai.message.data.MessageChain
+import net.mamoe.mirai.utils.SimpleLogger.LogPriority
 
 interface CommandSender {
     /**
      * 立刻发送一条Message
      */
+
     suspend fun sendMessage(messageChain: MessageChain)
 
     suspend fun sendMessage(message: String)
+
     /**
      * 写入要发送的内容 所有内容最后会被以一条发出
      */

--- a/mirai-console/src/main/kotlin/net/mamoe/mirai/console/plugins/PluginBase.kt
+++ b/mirai-console/src/main/kotlin/net/mamoe/mirai/console/plugins/PluginBase.kt
@@ -15,8 +15,10 @@ import kotlinx.coroutines.*
 import net.mamoe.mirai.console.MiraiConsole
 import net.mamoe.mirai.console.command.Command
 import net.mamoe.mirai.console.command.CommandSender
+import net.mamoe.mirai.console.pure.MiraiConsoleUIPure
 import net.mamoe.mirai.utils.MiraiLogger
 import net.mamoe.mirai.utils.SimpleLogger
+import net.mamoe.mirai.utils.SimpleLogger.LogPriority
 import java.io.File
 import java.io.InputStream
 import java.net.URLClassLoader
@@ -85,7 +87,7 @@ abstract class PluginBase
         this.coroutineContext[Job]!!.cancelChildren(throwable)
         try {
             this.onDisable()
-        }catch (e:Exception){
+        } catch (e: Exception) {
             logger.info(e)
         }
     }
@@ -93,10 +95,11 @@ abstract class PluginBase
     internal var pluginName: String = ""
 
     val logger: MiraiLogger by lazy {
-        SimpleLogger("Plugin $pluginName") { _, message, e ->
-            MiraiConsole.logger("[${pluginName}]", 0, message)
+        SimpleLogger("Plugin $pluginName") { priority, message, e ->
+            val identityString = "[${pluginName}]"
+            MiraiConsole.logger(priority, identityString, 0, message)
             if (e != null) {
-                MiraiConsole.logger("[${pluginName}]", 0, e)
+                MiraiConsole.logger(priority, identityString, 0, e)
             }
         }
     }

--- a/mirai-console/src/main/kotlin/net/mamoe/mirai/console/pure/MiraiConsoleUIPure.kt
+++ b/mirai-console/src/main/kotlin/net/mamoe/mirai/console/pure/MiraiConsoleUIPure.kt
@@ -15,6 +15,7 @@ import net.mamoe.mirai.console.MiraiConsole
 import net.mamoe.mirai.console.utils.MiraiConsoleUI
 import net.mamoe.mirai.utils.DefaultLoginSolver
 import net.mamoe.mirai.utils.LoginSolver
+import net.mamoe.mirai.utils.SimpleLogger.LogPriority
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.concurrent.thread
@@ -23,6 +24,22 @@ import kotlin.concurrent.thread
 class MiraiConsoleUIPure : MiraiConsoleUI {
     private var requesting = false
     private var requestStr = ""
+
+    @Suppress("unused")
+    companion object {
+        // ANSI color codes
+        const val COLOR_RED = "\u001b[38;5;196m"
+        const val COLOR_CYAN = "\u001b[38;5;87m"
+        const val COLOR_GREEN = "\u001b[38;5;82m"
+
+        // use a dark yellow(more like orange) instead of light one to save Solarized-light users
+        const val COLOR_YELLOW = "\u001b[38;5;220m"
+        const val COLOR_GREY = "\u001b[38;5;244m"
+        const val COLOR_BLUE = "\u001b[38;5;27m"
+        const val COLOR_NAVY = "\u001b[38;5;24m" // navy uniform blue
+        const val COLOR_PINK = "\u001b[38;5;207m"
+        const val COLOR_RESET = "\u001b[39;49m"
+    }
 
     init {
         thread {
@@ -38,11 +55,39 @@ class MiraiConsoleUIPure : MiraiConsoleUI {
         }
     }
 
-    val sdf by lazy{
+    val sdf by lazy {
         SimpleDateFormat("HH:mm:ss")
     }
+
     override fun pushLog(identity: Long, message: String) {
-        println("\u001b[0m " + sdf.format(Date()) +" $message")
+        println("\u001b[0m " + sdf.format(Date()) + " $message")
+    }
+
+    override fun pushLog(priority: LogPriority, identityStr: String, identity: Long, message: String) {
+        var priorityStr = "[${priority.name}]"
+        val _message = message + COLOR_RESET
+        if (MiraiConsole.frontEnd is MiraiConsoleUIPure) {
+            /**
+             * 通过ANSI控制码添加颜色
+             * 更多的颜色定义在 [MiraiConsoleUIPure] 的  companion
+             */
+            priorityStr = when (priority) {
+                LogPriority.ERROR
+                -> COLOR_RED + priorityStr + COLOR_RESET
+
+                LogPriority.WARNING
+                -> COLOR_RED + priorityStr + COLOR_RESET
+
+                LogPriority.VERBOSE
+                -> COLOR_NAVY + priorityStr + COLOR_RESET
+
+                LogPriority.DEBUG
+                -> COLOR_PINK + priorityStr + COLOR_RESET
+
+                else -> priorityStr
+            }
+            println("\u001b[0m " + sdf.format(Date()) + " $priorityStr $identityStr $_message")
+        }
     }
 
     override fun prePushBot(identity: Long) {

--- a/mirai-console/src/main/kotlin/net/mamoe/mirai/console/utils/MiraiConsoleUI.kt
+++ b/mirai-console/src/main/kotlin/net/mamoe/mirai/console/utils/MiraiConsoleUI.kt
@@ -11,6 +11,7 @@ package net.mamoe.mirai.console.utils
 
 import net.mamoe.mirai.Bot
 import net.mamoe.mirai.utils.LoginSolver
+import net.mamoe.mirai.utils.SimpleLogger.LogPriority
 
 /**
  * 只需要实现一个这个 传入MiraiConsole 就可以绑定UI层与Console层
@@ -24,6 +25,13 @@ interface MiraiConsoleUI {
      * identity：log所属的screen, Main=0; Bot=Bot.uin
      */
     fun pushLog(
+        identity: Long,
+        message: String
+    )
+
+    fun pushLog(
+        priority: LogPriority,
+        identityStr: String,
         identity: Long,
         message: String
     )


### PR DESCRIPTION
重写了接口中的pushLog部分, 给ConsolePure添加了色彩支持, (部分地)解决了 #7 的问题. 这个解决方案的副作用在于, `MiraiConsoleUI`的接口是Pure, Terminal, Graphical 共用的, 因此为了兼容修改 ~~(通过编译)~~ , 在另外两类里分别添加两个函数. 新增的函数什么也没做, 直接忽略了和log priority有关的形参, 并调用原有的pushLog.  
现在ComsolePure的效果如下
![image](https://user-images.githubusercontent.com/35602373/76850119-ac5bf900-6881-11ea-8b57-1c0111a8d648.png)
更加细致的色彩修改可以通过调用`MiraiConsoleUIPure`的伴生对象内定义的颜色来实现.
