### PR TITLE
Custom Command Prefix & Fix jvm option `classpath` invalid.

### DIFF
--- a/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/JCenterDownloader.kt
+++ b/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/JCenterDownloader.kt
@@ -139,5 +139,5 @@ internal suspend fun ByteReadChannel.saveToContent(filepath: String) {
 
 
 internal fun getContent(filepath: String):File{
-    return File(contentPath.absolutePath + "/" + filepath)
+    return File(contentPath, filepath)
 }

--- a/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/WrapperMain.kt
+++ b/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/WrapperMain.kt
@@ -15,16 +15,23 @@ import java.awt.TextArea
 import java.io.File
 import java.net.URLClassLoader
 import java.util.*
+import java.util.jar.JarFile
 import javax.swing.JFrame
 import javax.swing.JPanel
 
 
 val contentPath by lazy {
-    File(System.getProperty("user.dir") + "/content/").also {
+    File(System.getProperty("user.dir"), "content").also {
         if (!it.exists()) {
             it.mkdirs()
         }
     }
+}
+
+val extendedLibraries by lazy {
+    val file =
+        System.getProperty("mirai.libraries")?.let { File(it) } ?: File(System.getProperty("user.dir"), "libraries")
+    file.also { if (!it.exists()) it.mkdirs() }
 }
 
 object WrapperMain {
@@ -56,6 +63,7 @@ object WrapperMain {
             uiLog("正在进行版本检查\n")
             val dic = System.getProperty("user.dir")
             uiLog("工作目录: ${dic}\n")
+            uiLog("扩展库目录: ${extendedLibraries}\n")
             uiLog("若无法启动, 请尝试清除工作目录下/content/文件夹\n")
             var uiOpen = true
             GlobalScope.launch {
@@ -94,6 +102,7 @@ object WrapperMain {
 
     private fun preStartInNonNative() {
         println("You are running Mirai-Console-Wrapper under " + System.getProperty("user.dir"))
+        println("All additional libraries are located at $extendedLibraries")
         var type = WrapperProperties.determineConsoleType(WrapperProperties.content)
         if (type != null) {
             println("Starting Mirai Console $type, reset by clear /content/")
@@ -142,21 +151,15 @@ object WrapperMain {
         )
 
         loader.loadClass("net.mamoe.mirai.BotFactoryJvm")
+        loader.loadClass(
+            when (type) {
+                CONSOLE_PURE -> "net.mamoe.mirai.console.pure.MiraiConsolePureLoader"
+                CONSOLE_GRAPHICAL -> "net.mamoe.mirai.console.graphical.MiraiConsoleGraphicalLoader"
+                else -> return
+            }
+        ).getMethod("load", String::class.java, String::class.java)
+            .invoke(null, CoreUpdater.getCurrentVersion(), ConsoleUpdater.getCurrentVersion())
 
-        when (type) {
-            CONSOLE_PURE -> {
-                loader.loadClass(
-                        "net.mamoe.mirai.console.pure.MiraiConsolePureLoader"
-                    ).getMethod("load", String::class.java, String::class.java)
-                    .invoke(null, CoreUpdater.getCurrentVersion(), ConsoleUpdater.getCurrentVersion())
-            }
-            CONSOLE_GRAPHICAL -> {
-                loader.loadClass(
-                        "net.mamoe.mirai.console.graphical.MiraiConsoleGraphicalLoader"
-                    ).getMethod("load", String::class.java, String::class.java)
-                    .invoke(null, CoreUpdater.getCurrentVersion(), ConsoleUpdater.getCurrentVersion())
-            }
-        }
     }
 }
 
@@ -169,13 +172,38 @@ private class MiraiClassLoader(
     arrayOf(
         protocol.toURI().toURL(),
         console.toURI().toURL()
-    ), parent
-)
+    ), null
+) {
+    init {
+        extendedLibraries.listFiles { file ->
+            file.isFile && file.extension == "jar"
+        }?.forEach {
+            kotlin.runCatching {
+                /*
+                Confirm that the current jar is valid
+                确认当前jar是否有效
+                */
+                JarFile(it).close()
+                addURL(it.toURI().toURL())
+            }
+        }
+    }
+
+    private val parent0: ClassLoader? = parent
+    override fun findClass(name: String?): Class<*> {
+        return try {
+            super.findClass(name)
+        } catch (exception: ClassNotFoundException) {
+            if (parent0 == null) throw exception
+            parent0.loadClass(name)
+        }
+    }
+}
 
 
 private object WrapperProperties {
     val contentFile by lazy {
-        File(contentPath.absolutePath + "/.wrapper.txt").also {
+        File(contentPath, ".wrapper.txt").also {
             if (!it.exists()) it.createNewFile()
         }
     }

--- a/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/WrapperMain.kt
+++ b/mirai-console-wrapper/src/main/kotlin/net/mamoe/mirai/console/wrapper/WrapperMain.kt
@@ -138,7 +138,7 @@ object WrapperMain {
         val loader = MiraiClassLoader(
             CoreUpdater.getProtocolLib()!!,
             ConsoleUpdater.getFile()!!,
-            null
+            WrapperMain::class.java.classLoader
         )
 
         loader.loadClass("net.mamoe.mirai.BotFactoryJvm")

--- a/mirai-console/src/main/java/net/mamoe/mirai/console/command/JCommandManager.java
+++ b/mirai-console/src/main/java/net/mamoe/mirai/console/command/JCommandManager.java
@@ -1,6 +1,6 @@
 package net.mamoe.mirai.console.command;
 
-import jdk.jfr.Description;
+// import jdk.jfr.Description;
 
 public class JCommandManager {
 

--- a/mirai-console/src/main/kotlin/net/mamoe/mirai/console/command/CommandManager.kt
+++ b/mirai-console/src/main/kotlin/net/mamoe/mirai/console/command/CommandManager.kt
@@ -149,11 +149,11 @@ object CommandManager : Job by {
 
     private suspend fun processCommandImpl(sender: CommandSender, fullCommand: String): Boolean {
         val blocks = fullCommand.split(" ")
-        val commandHead = blocks[0].replace("/", "")
+        val commandHead = blocks[0] //.replace("/", "")
         val args = blocks.drop(1)
         return registeredCommand[commandHead]?.run {
             try {
-                return onCommand(sender, blocks.drop(1)).also {
+                return onCommand(sender, ArrayList(args)).also {
                     if (it) {
                         PluginManager.onCommand(this, sender, args)
                     } else {

--- a/mirai-console/src/main/kotlin/net/mamoe/mirai/console/command/DefaultCommands.kt
+++ b/mirai-console/src/main/kotlin/net/mamoe/mirai/console/command/DefaultCommands.kt
@@ -29,6 +29,7 @@ import java.util.*
  */
 
 object DefaultCommands {
+    private val commandPrefix = "mirai.command.prefix".property() ?: "/"
     private suspend fun CommandSender.login(account: Long, password: String) {
         MiraiConsole.logger("[Bot Login]", 0, "login...")
         try {
@@ -55,7 +56,7 @@ object DefaultCommands {
             }
             bot.login()
             bot.subscribeMessages {
-                startsWith("/") { message ->
+                startsWith(commandPrefix) { message ->
                     if (bot.checkManager(this.sender.id)) {
                         val sender = if (this is GroupMessage) {
                             GroupContactCommandSender(this.sender, this.subject)
@@ -83,8 +84,10 @@ object DefaultCommands {
         val account = ("mirai.account".property() ?: return).toLong()
         val password = "mirai.password".property() ?: "mirai.passphrase".property() ?: "mirai.passwd".property()
         if (password == null) {
-            MiraiConsole.logger.invoke(SimpleLogger.LogPriority.ERROR, "[AUTO LOGIN]", account,
-                "Find the account to be logged in, but no password specified")
+            MiraiConsole.logger.invoke(
+                SimpleLogger.LogPriority.ERROR, "[AUTO LOGIN]", account,
+                "Find the account to be logged in, but no password specified"
+            )
             return
         }
         GlobalScope.launch {

--- a/mirai-console/src/main/kotlin/net/mamoe/mirai/console/pure/MiraiConsoleUIPure.kt
+++ b/mirai-console/src/main/kotlin/net/mamoe/mirai/console/pure/MiraiConsoleUIPure.kt
@@ -43,7 +43,7 @@ class MiraiConsoleUIPure : MiraiConsoleUI {
     }
 
     init {
-        thread {
+        thread(name = "Mirai Console Input Thread") {
             while (true) {
                 val input = readLine() ?: return@thread
                 if (requesting) {


### PR DESCRIPTION
Fix jvm option `classpath` is invalid
Customizable command prefix (maybe this is not useful)