### PR TITLE
更正`/login`为`login`

### DIFF
--- a/mirai-console/src/main/kotlin/net/mamoe/mirai/console/MiraiConsole.kt
+++ b/mirai-console/src/main/kotlin/net/mamoe/mirai/console/MiraiConsole.kt
@@ -125,8 +125,8 @@ object MiraiConsole {
 
         /* 通知启动完成 */
         logger("Mirai-console 启动完成")
-        logger("\"/login qqnumber qqpassword \" to login a bot")
-        logger("\"/login qq号 qq密码 \" 来登录一个BOT")
+        logger("\"login qqnumber qqpassword \" to login a bot")
+        logger("\"login qq号 qq密码 \" 来登录一个BOT")
 
         /* 尝试从系统配置自动登录 */
         DefaultCommands.tryLoginAuto()


### PR DESCRIPTION
（