### PR TITLE
Ensure that the PermissionService is loaded correctly

### DIFF
--- a/backend/mirai-console/src/extension/ExtensionPoint.kt
+++ b/backend/mirai-console/src/extension/ExtensionPoint.kt
@@ -74,7 +74,7 @@ public abstract class AbstractSingletonExtensionPoint<E : SingletonExtension<T>,
      * 由 [SingletonExtensionSelector] 选择后的实例.
      */
     @ConsoleExperimentalApi
-    public val selectedInstance: T by lazy {
+    public open val selectedInstance: T by lazy {
         GlobalComponentStorage.run { this@AbstractSingletonExtensionPoint.findSingletonInstance(extensionType, builtinImplementation) }
     }
 }

--- a/backend/mirai-console/src/extensions/PermissionServiceProvider.kt
+++ b/backend/mirai-console/src/extensions/PermissionServiceProvider.kt
@@ -36,6 +36,7 @@ public interface PermissionServiceProvider : SingletonExtension<PermissionServic
             }
         }
 
+        @ConsoleExperimentalApi
         override val selectedInstance: PermissionService<*>
             get() {
                 if (!permissionServiceOk) {

--- a/backend/mirai-console/src/extensions/PermissionServiceProvider.kt
+++ b/backend/mirai-console/src/extensions/PermissionServiceProvider.kt
@@ -39,7 +39,7 @@ public interface PermissionServiceProvider : SingletonExtension<PermissionServic
         override val selectedInstance: PermissionService<*>
             get() {
                 if (!permissionServiceOk) {
-                    error("Permission Service not yet completed")
+                    error("PermissionService not yet loaded")
                 }
                 return super.selectedInstance
             }

--- a/backend/mirai-console/src/extensions/PermissionServiceProvider.kt
+++ b/backend/mirai-console/src/extensions/PermissionServiceProvider.kt
@@ -25,6 +25,8 @@ import net.mamoe.mirai.console.util.ConsoleExperimentalApi
 public interface PermissionServiceProvider : SingletonExtension<PermissionService<*>> {
     public companion object ExtensionPoint :
         AbstractSingletonExtensionPoint<PermissionServiceProvider, PermissionService<*>>(PermissionServiceProvider::class, BuiltInPermissionService) {
+        internal var permissionServiceOk = false
+
         @ConsoleExperimentalApi
         public val providerPlugin: Plugin? by lazy {
             GlobalComponentStorage.run {
@@ -33,6 +35,14 @@ public interface PermissionServiceProvider : SingletonExtension<PermissionServic
                 PermissionServiceProvider.getExtensions().find { it.extension.instance === instance }?.plugin
             }
         }
+
+        override val selectedInstance: PermissionService<*>
+            get() {
+                if (!permissionServiceOk) {
+                    error("Permission Service not yet completed")
+                }
+                return super.selectedInstance
+            }
     }
 }
 

--- a/backend/mirai-console/src/internal/MiraiConsoleImplementationBridge.kt
+++ b/backend/mirai-console/src/internal/MiraiConsoleImplementationBridge.kt
@@ -180,6 +180,7 @@ internal object MiraiConsoleImplementationBridge : CoroutineScope, MiraiConsoleI
         phase("load PermissionService") {
             mainLogger.verbose { "Loading PermissionService..." }
 
+            PermissionServiceProvider.permissionServiceOk = true
             PermissionService.INSTANCE.let { ps ->
                 if (ps is BuiltInPermissionService) {
                     ConsoleDataScope.addAndReloadConfig(ps.config)


### PR DESCRIPTION
如果插件在 `init{}`, 或者 `onLoad()` 使用到与权限有关的内容, 会导致权限系统提前加载并锁定, 间接导致提供权限服务的插件无效

此修改将从原来的 `调用即加载` 转为 `未加载直接（或间接）调用会 error`

影响范围:

```kotlin

object MyPlugin: KotlinPlugin(...) {

    val PERMISSION_EXECUTE_1 by lazy { // 无影响, lazy 不受影响
        PermissionService.INSTANCE.register(permissionId("execute1"), "注册权限的示例")
    }

    // error, 相当于在 init{} 块直接赋值
    val PERMISSION2 = PermissionService.INSTANCE.register(permissionId("execute1"), "注册权限的示例")

    val PERMISSION3: Permission
    init {
        PERMISSION3 = ...... // error: @see PERMISSION2
    }

    val PERMISSION_ID = permissionId("") // ERROR: 间接调用 PermissionService
    
    val PERMISSION_ID2 = PermissionId("a", "b") // 无影响
    
    override fun PluginComponentStorage.onLoad() {
        MyCommand.register() // ERROR: 间接调用 PermissionService
    }
    
    override fun onEnable() {
        // ..............
        // 无影响, PermissionService 已经加载
    }
}

```