### PR TITLE
Fix: CommandSender类型不满足要求时的提示文字错误

### DIFF
--- a/frontend/mirai-console-terminal/src/ConsoleThread.kt
+++ b/frontend/mirai-console-terminal/src/ConsoleThread.kt
@@ -150,8 +150,8 @@ internal fun UnmatchedCommandSignature.render(command: Command): String {
 @OptIn(ExperimentalCommandDescriptors::class)
 internal fun FailureReason.render(): String {
     return when (this) {
-        is FailureReason.InapplicableArgument -> "参数类型错误"
         is FailureReason.InapplicableReceiverArgument -> "需要由 ${this.parameter.renderAsName()} 执行"
+        is FailureReason.InapplicableArgument -> "参数类型错误"
         is FailureReason.TooManyArguments -> "参数过多"
         is FailureReason.NotEnoughArguments -> "参数不足"
         is FailureReason.ResolutionAmbiguity -> "调用歧义"


### PR DESCRIPTION
当命令要求的CommandSender与实际的CommandSender类型不符时，提示内容为`参数类型错误`而不是`需要由xxx执行`，如下图所示：
![image](https://user-images.githubusercontent.com/55307932/110800503-32edbf80-82b7-11eb-96c9-4c4ff78dd879.png)
推测原因为判断命令执行失败原因的类型时，由于`InapplicableReceiverArgument`是`InapplicableArgument`的子类导致所有的`InapplicableReceiverArgument`被当作`InapplicableArgument`处理，交换判断顺序应当能解决此问题。